### PR TITLE
Use default pluginsJsonFileName when deserializing DefaultUpdateRepository

### DIFF
--- a/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
@@ -36,6 +36,7 @@ import java.util.*;
  */
 public class DefaultUpdateRepository implements UpdateRepository {
 
+    private static final String DEFAULT_PLUGINS_JSON_FILENAME = "plugins.json";
     private static final Logger log = LoggerFactory.getLogger(DefaultUpdateRepository.class);
     private String id;
     private URL url;
@@ -43,14 +44,23 @@ public class DefaultUpdateRepository implements UpdateRepository {
 
     private Map<String, PluginInfo> plugins;
 
+    /**
+     * Instantiates a new default update repository. The default plugins JSON file
+     * name {@code plugins.json} will be used. Please use
+     * {@link #DefaultUpdateRepository(String, URL, String)} if you want to choose
+     * another file name than {@code plugins.json}}.
+     *
+     * @param id  the repository id
+     * @param url the repository url
+     */
     public DefaultUpdateRepository(String id, URL url) {
-        this(id, url, "plugins.json");
+        this(id, url, DEFAULT_PLUGINS_JSON_FILENAME);
     }
 
     public DefaultUpdateRepository(String id, URL url, String pluginsJsonFileName) {
-        this.id = id;
-        this.url = url;
-        this.pluginsJsonFileName = pluginsJsonFileName;
+	this.id = id;
+	this.url = url;
+	this.pluginsJsonFileName = pluginsJsonFileName;
     }
 
     @Override
@@ -80,7 +90,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
-            URL pluginsUrl = new URL(getUrl(), pluginsJsonFileName);
+            URL pluginsUrl = new URL(getUrl(), getPluginsJsonFileName());
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
             pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
         } catch (Exception e) {
@@ -132,14 +142,23 @@ public class DefaultUpdateRepository implements UpdateRepository {
         return new CompoundVerifier();
     }
 
+    /**
+     * Gets the plugins json file name. Returns {@code plugins.json} if null.
+     *
+     * @return the plugins json file name
+     */
     public String getPluginsJsonFileName() {
+        if (pluginsJsonFileName == null) {
+            pluginsJsonFileName = DEFAULT_PLUGINS_JSON_FILENAME;
+        }
         return pluginsJsonFileName;
     }
 
     /**
      * Choose another file name than {@code plugins.json}.
      *
-     * @param pluginsJsonFileName the name (relative) of plugins.json file
+     * @param pluginsJsonFileName the name (relative) of plugins.json file. If null,
+     *                            will default to {@code plugins.json}
      */
     public void setPluginsJsonFileName(String pluginsJsonFileName) {
         this.pluginsJsonFileName = pluginsJsonFileName;

--- a/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
@@ -38,6 +38,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
 
     private static final String DEFAULT_PLUGINS_JSON_FILENAME = "plugins.json";
     private static final Logger log = LoggerFactory.getLogger(DefaultUpdateRepository.class);
+
     private String id;
     private URL url;
     private String pluginsJsonFileName;
@@ -151,14 +152,15 @@ public class DefaultUpdateRepository implements UpdateRepository {
         if (pluginsJsonFileName == null) {
             pluginsJsonFileName = DEFAULT_PLUGINS_JSON_FILENAME;
         }
+
         return pluginsJsonFileName;
     }
 
     /**
      * Choose another file name than {@code plugins.json}.
      *
-     * @param pluginsJsonFileName the name (relative) of plugins.json file. If null,
-     *                            will default to {@code plugins.json}
+     * @param pluginsJsonFileName the name (relative) of plugins.json file. 
+	 * If null, will default to {@code plugins.json}
      */
     public void setPluginsJsonFileName(String pluginsJsonFileName) {
         this.pluginsJsonFileName = pluginsJsonFileName;

--- a/src/test/java/org/pf4j/update/DefaultUpdateRepositoryTest.java
+++ b/src/test/java/org/pf4j/update/DefaultUpdateRepositoryTest.java
@@ -1,0 +1,21 @@
+package org.pf4j.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class DefaultUpdateRepositoryTest {
+
+    @Test
+    public void shouldUseDefaultPluginJsonFileNameWhenDeserializedFromJson() {
+        Gson gson = new GsonBuilder().create();
+        String repositoryJson = "{\"id\": \"localhost\",\"url\": \"http://localhost:8081/\"}";
+        DefaultUpdateRepository repository = gson.fromJson(repositoryJson, DefaultUpdateRepository.class);
+        assertNotNull(repository);
+        assertEquals("plugins.json", repository.getPluginsJsonFileName());
+    }
+}

--- a/src/test/java/org/pf4j/update/DefaultUpdateRepositoryTest.java
+++ b/src/test/java/org/pf4j/update/DefaultUpdateRepositoryTest.java
@@ -1,3 +1,19 @@
+
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.pf4j.update;
 
 import static org.junit.Assert.assertEquals;
@@ -18,4 +34,5 @@ public class DefaultUpdateRepositoryTest {
         assertNotNull(repository);
         assertEquals("plugins.json", repository.getPluginsJsonFileName());
     }
+
 }


### PR DESCRIPTION
* Use 'plugins.json' as the default pluginsJsonFileName when
deserializing org.pf4j.update.DefaultUpdateRepository.