### PR TITLE
replace existing plugin artifact on move

### DIFF
--- a/src/main/java/org/pf4j/update/UpdateManager.java
+++ b/src/main/java/org/pf4j/update/UpdateManager.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 /**
  * @author Decebal Suiu
  */
@@ -366,7 +368,7 @@ public class UpdateManager {
         Path pluginsRoot = pluginManager.getPluginsRoot();
         Path file = pluginsRoot.resolve(downloaded.getFileName());
         try {
-            Files.move(downloaded, file);
+            Files.move(downloaded, file, REPLACE_EXISTING);
         } catch (IOException e) {
             throw new PluginRuntimeException("Failed to write plugin file {} to plugin folder", file);
         }


### PR DESCRIPTION
Existing functionality will throw an IOException if the plugin has already been downloaded (like, in the case of running an application via IntelliJ and repeatedly restarting). This makes it so that previous downloads are just replaced, rather than causing the application to crash.