### PR TITLE
fix(update-manager): Check if repositoriesJson file exists before initializing repositories from file

### DIFF
--- a/src/main/java/org/pf4j/update/UpdateManager.java
+++ b/src/main/java/org/pf4j/update/UpdateManager.java
@@ -219,7 +219,7 @@ public class UpdateManager {
      * Refreshes all repositories, so they are forced to refresh list of plugins.
      */
     public synchronized void refresh() {
-        if (repositoriesJson != null) {
+        if (repositoriesJson != null && Files.exists(repositoriesJson)) {
             initRepositoriesFromJson();
         }
         for (UpdateRepository updateRepository : repositories) {


### PR DESCRIPTION
Without this, `initRepositoriesFromJson` throws a `FileNotFoundException`.