### PR TITLE
Allow customisation of how a URL is loaded.

### DIFF
--- a/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/org/pf4j/update/DefaultUpdateRepository.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.IOException;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -88,12 +90,16 @@ public class DefaultUpdateRepository implements UpdateRepository {
         return getPlugins().get(id);
     }
 
+    protected InputStream openURL(URL url) throws IOException {
+    	return url.openStream();
+    }
+    
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
             URL pluginsUrl = new URL(getUrl(), getPluginsJsonFileName());
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
-            pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
+            pluginsJsonReader = new InputStreamReader(openURL(pluginsUrl));
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             plugins = Collections.emptyMap();


### PR DESCRIPTION
I have added a protected method to delegate the opening of a URL so that it can be overridden should a project need to modify how a URL file is downloaded.